### PR TITLE
Fix: Missing args on SFIP initialization

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -691,6 +691,7 @@ export class Constellation<T extends ServicesLibp2p = ServicesLibp2p> {
       sfipFinale = (await initSFIP({
         dossier: await join(await this.dossier(), "sfip"),
         domaines: this._opts.domaines,
+        pairsParDéfaut: this._opts.pairsParDéfaut,
         clefPrivée,
       })) as unknown as HeliaLibp2p<Libp2p<T>>;
 

--- a/src/sfip/index.ts
+++ b/src/sfip/index.ts
@@ -104,6 +104,7 @@ export async function initSFIP({
     dossier,
     domaines,
     pairsParDéfaut,
+    clefPrivée,
   });
 
   configParDéfaut.privateKey = clefPrivée;


### PR DESCRIPTION
Hi @julienmalard 

I found these two missing parameters in the SFIP initialization. They were needed to make the pairPerDefault and domains configuration work properly.